### PR TITLE
feat: Clean up events page with coming soon message

### DIFF
--- a/src/pages/events.module.css
+++ b/src/pages/events.module.css
@@ -252,6 +252,96 @@
     text-decoration: none;
 }
 
+/* Coming Soon Section */
+.comingSoonSection {
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+    margin: 3rem 0;
+    align-items: center;
+}
+
+.comingSoonCard {
+    text-align: center;
+    padding: 3rem 2rem;
+    border-radius: 16px;
+    background: linear-gradient(135deg, rgba(34, 211, 238, 0.05) 0%, rgba(34, 238, 139, 0.05) 100%);
+    border: 1px solid rgba(34, 211, 238, 0.2);
+    max-width: 600px;
+    width: 100%;
+}
+
+.comingSoonTitle {
+    font-size: 2rem;
+    font-weight: 600;
+    background: linear-gradient(135deg, var(--ifm-color-primary) 0%, #22ee8b 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    margin-bottom: 1rem;
+}
+
+.comingSoonText {
+    font-size: 1.1rem;
+    line-height: 1.7;
+    color: var(--ifm-font-color-secondary);
+}
+
+.hackathonDateCard {
+    text-align: center;
+    padding: 2.5rem 3rem;
+    border-radius: 16px;
+    background: linear-gradient(135deg, rgba(34, 211, 238, 0.1) 0%, rgba(34, 238, 139, 0.1) 100%);
+    border: 2px solid var(--ifm-color-primary);
+    max-width: 500px;
+    width: 100%;
+    position: relative;
+    overflow: hidden;
+}
+
+.hackathonDateCard::before {
+    content: "";
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background: radial-gradient(circle, rgba(34, 211, 238, 0.1) 0%, transparent 70%);
+    animation: rotate 20s linear infinite;
+}
+
+@keyframes rotate {
+    to { transform: rotate(360deg); }
+}
+
+.saveTheDate {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    color: var(--ifm-color-primary);
+    margin-bottom: 1rem;
+    font-weight: 500;
+}
+
+.hackathonTitle {
+    font-size: 1.8rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+    color: var(--ifm-heading-color);
+}
+
+.hackathonDate {
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: var(--ifm-color-primary);
+    margin-bottom: 0.5rem;
+}
+
+.hackathonLocation {
+    font-size: 1rem;
+    color: var(--ifm-font-color-secondary);
+}
+
 /* Final event - Hackathon */
 .timelineFinalEvent {
     position: relative;

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -3,109 +3,6 @@ import Layout from "@theme/Layout";
 import styles from "./events.module.css";
 import { ParticleBackground } from "../components/ParticleBackground";
 
-// Event data structure
-type EventItem = {
-  id: number;
-  title: string;
-  date: string;
-  time: string;
-  location: string;
-  description: string;
-  type: "workshop" | "meetup" | "talk" | "info";
-  registrationLink?: string;
-};
-
-// Sample event data - replace with your actual events
-const EVENTS: EventItem[] = [
-  {
-    id: 1,
-    title: "GovTech Info Session",
-    date: "10.11.2025",
-    time: "19:00 - 21:00",
-    location: "East Side Fab e.V., Eschberger Weg 40, Saarbrücken",
-    description:
-      "Erfahre mehr über den kommenden GovTech Hackathon, lerne das Team kennen und stelle deine Fragen. Wir geben einen Überblick über die Challenges und Technologien.",
-    type: "info",
-    registrationLink: "/anmelden",
-  },
-  {
-    id: 2,
-    title: "Open Data Workshop",
-    date: "25.11.2025",
-    time: "10:00 - 16:00",
-    location: "East Side Fab e.V., Eschberger Weg 40, Saarbrücken",
-    description:
-      "In diesem Workshop lernst du, wie du mit öffentlichen Daten arbeiten kannst. Wir zeigen dir die wichtigsten Quellen und Tools für den Umgang mit Open Government Data.",
-    type: "workshop",
-    registrationLink: "/anmelden",
-  },
-  {
-    id: 3,
-    title: "GovTech Meetup: Digitales Bürgerzentrum",
-    date: "05.12.2025",
-    time: "18:30 - 20:30",
-    location: "Online (Zoom)",
-    description:
-      "Ein Experten-Talk zum Thema digitale Bürgerdienste. Was funktioniert bereits gut und wo gibt es noch Verbesserungspotential?",
-    type: "meetup",
-    registrationLink: "/anmelden",
-  },
-  {
-    id: 4,
-    title: "API-Workshop: Schnittstellen im öffentlichen Sektor",
-    date: "15.12.2025",
-    time: "14:00 - 17:00",
-    location: "East Side Fab e.V., Eschberger Weg 40, Saarbrücken",
-    description:
-      "Diese Session führt dich in die API-Landschaft des öffentlichen Sektors ein. Lerne, wie du vorhandene Schnittstellen nutzen und eigene entwickeln kannst.",
-    type: "workshop",
-    registrationLink: "/anmelden",
-  },
-];
-
-// Event card component
-const EventCard = ({ event }: { event: EventItem }) => {
-  return (
-    <div className={`${styles.eventCard} ${styles[`eventType${event.type}`]}`}>
-      <div className={styles.eventMeta}>
-        <div className={styles.eventDate}>
-          <div className={styles.eventDay}>{event.date}</div>
-          <div className={styles.eventTime}>{event.time}</div>
-        </div>
-        <div className={styles.eventTypeLabel}>
-          {getEventTypeLabel(event.type)}
-        </div>
-      </div>
-
-      <div className={styles.eventContent}>
-        <h3 className={styles.eventTitle}>{event.title}</h3>
-        <div className={styles.eventLocation}>
-          <span className={styles.locationIcon}>📍</span> {event.location}
-        </div>
-        <p className={styles.eventDescription}>{event.description}</p>
-        {event.registrationLink && (
-          <div className={styles.eventActions}>
-            <a href={event.registrationLink} className={styles.registerButton}>
-              Anmelden
-            </a>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-};
-
-// Helper function to get human-readable event type labels
-const getEventTypeLabel = (type: EventItem["type"]): string => {
-  const labels = {
-    workshop: "Workshop",
-    meetup: "Meetup",
-    talk: "Vortrag",
-    info: "Info Session",
-  };
-  return labels[type];
-};
-
 export default function EventsPage(): JSX.Element {
   return (
     <Layout
@@ -131,41 +28,39 @@ export default function EventsPage(): JSX.Element {
             <p className={styles.introText}>
               Der GovTech Hackathon wird von verschiedenen Veranstaltungen
               begleitet, die dir helfen, dich optimal vorzubereiten und andere
-              Teilnehmer kennenzulernen. Hier findest du alle kommenden Events.
+              Teilnehmer kennenzulernen.
             </p>
           </div>
 
-          <div className={styles.timeline}>
-            <div className={styles.timelineLine}></div>
-            <div className={styles.eventsContainer}>
-              {EVENTS.map((event) => (
-                <div className={styles.timelineEvent} key={event.id}>
-                  <div className={styles.timelineDot}></div>
-                  <EventCard event={event} />
-                </div>
-              ))}
-              <div className={styles.timelineFinalEvent}>
-                <div className={styles.finalEventDot}></div>
-                <div className={styles.finalEventCard}>
-                  <h3>Hackathon</h3>
-                  <div className={styles.finalEventDate}>11. & 12. Oktober 2025</div>
-                </div>
-              </div>
+          <div className={styles.comingSoonSection}>
+            <div className={styles.comingSoonCard}>
+              <h2 className={styles.comingSoonTitle}>More information coming soon</h2>
+              <p className={styles.comingSoonText}>
+                Wir arbeiten gerade an einem spannenden Veranstaltungsprogramm für dich.
+                Schau bald wieder vorbei oder melde dich an, um Updates zu erhalten.
+              </p>
+            </div>
+            
+            <div className={styles.hackathonDateCard}>
+              <h3 className={styles.saveTheDate}>Save the Date</h3>
+              <div className={styles.hackathonTitle}>GovTech Hackathon</div>
+              <div className={styles.hackathonDate}>11. & 12. Oktober 2025</div>
+              <div className={styles.hackathonLocation}>East Side Fab e.V., Saarbrücken</div>
             </div>
           </div>
 
           <div className={styles.ctaSection}>
             <h2>Werde Teil des GovTech Ökosystems</h2>
             <p>
-              Melde dich jetzt für unsere Events an und bereite dich optimal auf
-              den Hackathon vor. Die Teilnahme an den
+              Melde dich jetzt an und sei als Erste*r dabei, wenn wir neue
+              Events ankündigen. Die Teilnahme an den
               Vorbereitungsveranstaltungen ist kostenlos.
             </p>
             <div className={styles.ctaButtons}>
-              <a href=" anmelden" className={styles.primaryButton}>
+              <a href="/anmelden" className={styles.primaryButton}>
                 Zur Anmeldung
               </a>
-              <a href="docs/faq" className={styles.secondaryButton}>
+              <a href="/docs/faq" className={styles.secondaryButton}>
                 FAQ
               </a>
             </div>


### PR DESCRIPTION
## Summary
This PR cleans up the events page by removing all placeholder events and adding a "coming soon" message as requested in #7.

## Changes Made
- ✅ Removed all 4 placeholder events from the events page
- ✅ Added "More information coming soon" message in English as specified
- ✅ Created a prominent "Save the Date" card for the hackathon (11. & 12. Oktober 2025)
- ✅ Enhanced styling with gradient cards and subtle animations
- ✅ Updated intro text to maintain context while simplifying content

## Visual Updates
- Clean, minimalist design with focus on the coming soon message
- Eye-catching Save the Date card with gradient borders
- Maintained visual appeal despite reduced content
- Responsive layout that works on all screen sizes

## Testing
- ✅ Build completes successfully
- ✅ Page renders correctly with new layout
- ✅ All links work properly

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)