### PR TITLE
feat: Add internationalization support for German/English

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -51,8 +51,8 @@ const config: Config = {
 
   // Set the default language for the site
   i18n: {
-    defaultLocale: "en",
-    locales: ["en"],
+    defaultLocale: "de",
+    locales: ["de", "en"],
   },
 
   presets: [
@@ -105,6 +105,10 @@ const config: Config = {
         },
         { to: "/events", label: "Events", position: "left" },
         { to: "/anmelden", label: "Anmelden", position: "left" },
+        {
+          type: "localeDropdown",
+          position: "right",
+        },
         {
           href: "https://github.com/East-Side-Fab/govtech-website",
           label: "GitHub",

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -1,0 +1,54 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "This page crashed.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Scroll back to top",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Archive",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Archive",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Blog list page navigation",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Newer Entries",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Older Entries",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Blog post page navigation",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Newer Post",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Older Post",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.post.plurals": {
+    "message": "One post|{count} posts",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} tagged with \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "View All Tags",
+    "description": "The label of the link targeting the tag list page"
+  }
+}

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -1,0 +1,50 @@
+{
+  "link.title.Resources": {
+    "message": "Resources",
+    "description": "The title of the footer links column with title=Resources"
+  },
+  "link.title.Community": {
+    "message": "Community", 
+    "description": "The title of the footer links column with title=Community"
+  },
+  "link.title.More": {
+    "message": "More",
+    "description": "The title of the footer links column with title=More"
+  },
+  "link.item.label.Information": {
+    "message": "Information",
+    "description": "The label of footer link with label=Information linking to /docs/intro"
+  },
+  "link.item.label.Events": {
+    "message": "Events",
+    "description": "The label of footer link with label=Events linking to /events"
+  },
+  "link.item.label.Anmelden": {
+    "message": "Register",
+    "description": "The label of footer link with label=Register linking to /anmelden"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to Discord"
+  },
+  "link.item.label.Twitter": {
+    "message": "Twitter",
+    "description": "The label of footer link with label=Twitter linking to Twitter"
+  },
+  "link.item.label.East Side Fab e.V.": {
+    "message": "East Side Fab e.V.",
+    "description": "The label of footer link with label=East Side Fab e.V. linking to https://eastsidefab.de"
+  },
+  "link.item.label.Impressum": {
+    "message": "Legal Notice",
+    "description": "The label of footer link with label=Legal Notice linking to https://eastsidefab.de/impressum/"
+  },
+  "link.item.label.Datenschutz": {
+    "message": "Privacy Policy",
+    "description": "The label of footer link with label=Privacy Policy linking to /datenschutz"
+  },
+  "copyright": {
+    "message": "Copyright © 2025 GovTech Hackathon | East Side Fab e.V.",
+    "description": "The footer copyright"
+  }
+}

--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,22 @@
+{
+  "title": {
+    "message": "GovTech Hackathon",
+    "description": "The title in the navbar"
+  },
+  "item.label.Info": {
+    "message": "Info",
+    "description": "Navbar item with label Info"
+  },
+  "item.label.Events": {
+    "message": "Events",
+    "description": "Navbar item with label Events"
+  },
+  "item.label.Anmelden": {
+    "message": "Register",
+    "description": "Navbar item with label Register"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}

--- a/src/pages/anmelden.en.tsx
+++ b/src/pages/anmelden.en.tsx
@@ -1,0 +1,262 @@
+import React, { useState } from "react";
+import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
+import styles from "./anmelden.module.css";
+import { GlitchText } from "../components/GlitchText";
+import { ParticleBackground } from "../components/ParticleBackground";
+
+// Registration form component
+const RegistrationForm = () => {
+  const [email, setEmail] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [organization, setOrganization] = useState("");
+  const [eventUpdates, setEventUpdates] = useState(false);
+  const [newsletter, setNewsletter] = useState(false);
+  const [formError, setFormError] = useState("");
+  const [status, setStatus] = useState("idle"); // idle, sending, success, error
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setFormError("");
+    setMessage("");
+
+    if (!email || !firstName) {
+      setFormError("Please fill out all required fields");
+      return;
+    }
+
+    try {
+      setStatus("sending");
+
+      // Prepare data for the API
+      const formData = {
+        mail: email,
+        first_name: firstName,
+        last_name: lastName || "",
+        organisation: organization || "",
+        event_updates: eventUpdates,
+        newsletter: newsletter
+      };
+
+      // Send data to the Fermyon API
+      const response = await fetch(
+        "https://participants-pp4aag1w.fermyon.app/participants",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(formData),
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`Registration failed: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      setStatus("success");
+      setMessage(
+        "Registration successful! We have registered you in our participant database.",
+      );
+    } catch (error) {
+      console.error("Registration error:", error);
+      setStatus("error");
+      setMessage(
+        error.message ||
+          "Registration failed. Please try again later.",
+      );
+    }
+  };
+
+  return (
+    <div className={styles.formContainer}>
+      <div className={styles.formHeader}>
+        <h3 className={styles.formTitle}>Registration Form</h3>
+      </div>
+
+      <div className={styles.formContent}>
+        {status === "sending" && (
+          <div className={styles.formStatus}>
+            <div className={styles.loader}></div>
+            <span>Your registration is being processed...</span>
+          </div>
+        )}
+
+        {status === "error" && (
+          <div className={styles.formError}>
+            <span className={styles.errorIcon}>!</span>
+            <div>{message}</div>
+          </div>
+        )}
+
+        {status === "success" && (
+          <div className={styles.formSuccess}>
+            <div className={styles.successAnimation}>
+              <span className={styles.checkmark}>✓</span>
+            </div>
+            <h3>Registration Successful!</h3>
+            <p>
+              We have registered you in our participant database and
+              will inform you about the next steps.
+            </p>
+          </div>
+        )}
+
+        {status !== "success" ? (
+          <form onSubmit={handleSubmit}>
+            <div className={styles.formRow}>
+              <div className={styles.inputField}>
+                <label>
+                  <span className={styles.fieldName}>First Name</span>
+                  <span className={styles.requiredMark}>*</span>
+                </label>
+                <div className={styles.inputWrapper}>
+                  <input
+                    type="text"
+                    value={firstName}
+                    onChange={(e) => setFirstName(e.target.value)}
+                    placeholder="John"
+                    required
+                  />
+                </div>
+              </div>
+
+              <div className={styles.inputField}>
+                <label>
+                  <span className={styles.fieldName}>Last Name</span>
+                </label>
+                <div className={styles.inputWrapper}>
+                  <input
+                    type="text"
+                    value={lastName}
+                    onChange={(e) => setLastName(e.target.value)}
+                    placeholder="Doe"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className={styles.inputField}>
+              <label>
+                <span className={styles.fieldName}>Email</span>
+                <span className={styles.requiredMark}>*</span>
+              </label>
+              <div className={styles.inputWrapper}>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="your.email@example.com"
+                  required
+                />
+              </div>
+            </div>
+
+            <div className={styles.inputField}>
+              <label>
+                <span className={styles.fieldName}>Organization</span>
+              </label>
+              <div className={styles.inputWrapper}>
+                <input
+                  type="text"
+                  value={organization}
+                  onChange={(e) => setOrganization(e.target.value)}
+                  placeholder="Your Organization"
+                />
+              </div>
+            </div>
+
+            <div className={styles.checkboxGroup}>
+              <div className={styles.checkboxField}>
+                <label className={styles.checkboxLabel}>
+                  <input
+                    type="checkbox"
+                    checked={eventUpdates}
+                    onChange={(e) => setEventUpdates(e.target.checked)}
+                    className={styles.checkbox}
+                  />
+                  <span className={styles.checkboxText}>
+                    Yes, I would like to receive information about similar 
+                    events after the event and participate in the feedback 
+                    survey. (Can be revoked at any time)
+                  </span>
+                </label>
+              </div>
+
+              <div className={styles.checkboxField}>
+                <label className={styles.checkboxLabel}>
+                  <input
+                    type="checkbox"
+                    checked={newsletter}
+                    onChange={(e) => setNewsletter(e.target.checked)}
+                    className={styles.checkbox}
+                  />
+                  <span className={styles.checkboxText}>
+                    Yes, I subscribe to the East Side Fab newsletter to receive 
+                    information about other exciting events and updates.
+                    Information about{" "}
+                    <Link to="/datenschutz" className={styles.privacyLink}>
+                      data protection
+                    </Link>{" "}
+                    and revocation have been read.
+                  </span>
+                </label>
+              </div>
+            </div>
+
+            {formError && (
+              <div className={styles.formError}>
+                <span className={styles.errorIcon}>!</span>
+                <span>{formError}</span>
+              </div>
+            )}
+
+            <div className={styles.formActions}>
+              <button type="submit" className={styles.submitButton}>
+                Register now
+              </button>
+            </div>
+          </form>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default function RegistrationPage(): React.ReactElement {
+  return (
+    <Layout
+      title="Register | GovTech Hackathon"
+      description="Register for the GovTech Hackathon and help shape the public sector"
+    >
+      <ParticleBackground />
+
+      <header className={styles.header}>
+        <div className={styles.gridOverlay}></div>
+        <div className={styles.headerContent}>
+          <h1>Registration</h1>
+          <div className={styles.headerDescription}>
+            <span className={styles.descriptionText}>
+              Be part of the initiative to modernize the public sector
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <main className={styles.mainContent}>
+        <section className={styles.registrationSection}>
+          <p className={styles.sectionText}>
+            Register for the GovTech Hackathon and become part of our
+            community. We will inform you about upcoming events,
+            challenges and important updates.
+          </p>
+
+          <RegistrationForm />
+        </section>
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/datenschutz.en.tsx
+++ b/src/pages/datenschutz.en.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import styles from "./datenschutz.module.css";
+
+export default function PrivacyPolicyPage(): React.ReactElement {
+  return (
+    <Layout
+      title="Privacy Policy | GovTech Hackathon"
+      description="Privacy Policy for the GovTech Hackathon"
+    >
+      <main className={styles.mainContent}>
+        <div className={styles.container}>
+          <header className={styles.header}>
+            <h1>Privacy Policy</h1>
+            <p className={styles.lastUpdated}>Last updated: January 2025</p>
+          </header>
+
+          <section className={styles.section}>
+            <h2>1. Data Controller</h2>
+            <p>
+              East Side Fab e.V.<br />
+              Eschberger Weg 40<br />
+              66121 Saarbrücken, Germany<br />
+              Email: info@eastsidefab.de
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h2>2. Data Collection and Processing</h2>
+            <p>
+              We collect and process the following personal data when you register for the GovTech Hackathon:
+            </p>
+            <ul>
+              <li>First name and last name</li>
+              <li>Email address</li>
+              <li>Organization (optional)</li>
+              <li>Communication preferences</li>
+            </ul>
+          </section>
+
+          <section className={styles.section}>
+            <h2>3. Purpose of Data Processing</h2>
+            <p>We process your data for the following purposes:</p>
+            <ul>
+              <li>Registration and management of hackathon participants</li>
+              <li>Communication about the event and related activities</li>
+              <li>Sending newsletters (only with your consent)</li>
+              <li>Event feedback and follow-up surveys (only with your consent)</li>
+            </ul>
+          </section>
+
+          <section className={styles.section}>
+            <h2>4. Legal Basis</h2>
+            <p>
+              The processing of your personal data is based on:
+            </p>
+            <ul>
+              <li>Your consent (Article 6(1)(a) GDPR) for newsletters and event updates</li>
+              <li>Legitimate interests (Article 6(1)(f) GDPR) for event organization</li>
+            </ul>
+          </section>
+
+          <section className={styles.section}>
+            <h2>5. Data Sharing</h2>
+            <p>
+              We do not share your personal data with third parties except:
+            </p>
+            <ul>
+              <li>When required by law</li>
+              <li>With your explicit consent</li>
+              <li>With our technical service providers under data processing agreements</li>
+            </ul>
+          </section>
+
+          <section className={styles.section}>
+            <h2>6. Data Retention</h2>
+            <p>
+              We retain your personal data only as long as necessary for the purposes 
+              mentioned above or as required by law. Event registration data is 
+              typically deleted within one year after the event.
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h2>7. Your Rights</h2>
+            <p>Under the GDPR, you have the following rights:</p>
+            <ul>
+              <li>Right to access your personal data</li>
+              <li>Right to rectification of incorrect data</li>
+              <li>Right to erasure ("right to be forgotten")</li>
+              <li>Right to restriction of processing</li>
+              <li>Right to data portability</li>
+              <li>Right to object to processing</li>
+              <li>Right to withdraw consent at any time</li>
+            </ul>
+            <p>
+              To exercise these rights, please contact us at info@eastsidefab.de
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h2>8. Cookies and Website Analytics</h2>
+            <p>
+              This website uses minimal cookies necessary for functionality. 
+              We do not use tracking or analytics cookies without your consent.
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h2>9. Changes to This Privacy Policy</h2>
+            <p>
+              We may update this privacy policy from time to time. 
+              Any changes will be posted on this page with an updated date.
+            </p>
+          </section>
+
+          <section className={styles.section}>
+            <h2>10. Contact</h2>
+            <p>
+              If you have any questions about this privacy policy or our 
+              data processing practices, please contact us at:
+            </p>
+            <p>
+              Email: info@eastsidefab.de<br />
+              Phone: +49 (0)681 XXX XXXX
+            </p>
+          </section>
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/events.en.tsx
+++ b/src/pages/events.en.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import styles from "./events.module.css";
+import { GlitchText } from "../components/GlitchText";
+import { ParticleBackground } from "../components/ParticleBackground";
+
+export default function EventsPage(): React.ReactElement {
+  return (
+    <Layout
+      title="Events | GovTech Hackathon"
+      description="Upcoming events and activities for the GovTech Hackathon"
+    >
+      <ParticleBackground />
+
+      <header className={styles.header}>
+        <div className={styles.gridOverlay}></div>
+        <div className={styles.headerContent}>
+          <GlitchText text="Events" element="h1" />
+          <div className={styles.headerDescription}>
+            <span className={styles.descriptionText}>
+              Upcoming activities and events
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <main className={styles.mainContent}>
+        <section className={styles.eventsSection}>
+          <div className={styles.eventCard}>
+            <div className={styles.eventDate}>
+              <span className={styles.month}>Oct</span>
+              <span className={styles.day}>11-12</span>
+              <span className={styles.year}>2025</span>
+            </div>
+            <div className={styles.eventContent}>
+              <h2 className={styles.eventTitle}>GovTech Hackathon</h2>
+              <p className={styles.eventDescription}>
+                Main hackathon event where teams will work on challenges 
+                to improve public sector services and digital governance.
+              </p>
+              <div className={styles.eventLocation}>
+                📍 East Side Fab e.V., Saarbrücken
+              </div>
+            </div>
+          </div>
+
+          <div className={styles.eventCard}>
+            <div className={styles.eventDate}>
+              <span className={styles.month}>Sep</span>
+              <span className={styles.day}>TBD</span>
+              <span className={styles.year}>2025</span>
+            </div>
+            <div className={styles.eventContent}>
+              <h2 className={styles.eventTitle}>Pre-Event Meetup</h2>
+              <p className={styles.eventDescription}>
+                Meet fellow participants, learn about the challenges, 
+                and start forming teams before the main event.
+              </p>
+              <div className={styles.eventLocation}>
+                📍 Location to be announced
+              </div>
+            </div>
+          </div>
+
+          <div className={styles.eventCard}>
+            <div className={styles.eventDate}>
+              <span className={styles.month}>Nov</span>
+              <span className={styles.day}>TBD</span>
+              <span className={styles.year}>2025</span>
+            </div>
+            <div className={styles.eventContent}>
+              <h2 className={styles.eventTitle}>Demo Day & Awards</h2>
+              <p className={styles.eventDescription}>
+                Present your solutions to the public and celebrate 
+                the best projects from the hackathon.
+              </p>
+              <div className={styles.eventLocation}>
+                📍 Location to be announced
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.ctaSection}>
+          <h2 className={styles.ctaTitle}>Stay Updated</h2>
+          <p className={styles.ctaText}>
+            Register now to receive updates about all events and activities
+          </p>
+          <div className={styles.ctaButtonContainer}>
+            <a href="/anmelden" className={styles.ctaButton}>
+              Register for Updates
+            </a>
+          </div>
+        </section>
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -1,0 +1,251 @@
+import React, { useEffect } from "react";
+import Layout from "@theme/Layout";
+import CodeBlock from "@theme/CodeBlock";
+import styles from "./index.module.css";
+import { GlitchText } from "../components/GlitchText";
+import { ParticleBackground } from "../components/ParticleBackground";
+import { CountdownTimer } from "../components/CountdownTimer";
+import TopicCarousel from "../components/TopicCarousel";
+
+export default function Hackathon(): JSX.Element {
+  // Typing effect for terminal section
+  useEffect(() => {
+    const terminalLines = document.querySelectorAll(`.${styles.terminalLine}`);
+    terminalLines.forEach((line, index) => {
+      setTimeout(
+        () => {
+          line.classList.add(styles.visible);
+        },
+        300 * (index + 1),
+      );
+    });
+  }, []);
+
+  return (
+    <Layout
+      title="GovTech Hackathon"
+      description="Open Government Hackathon – Boost the Public Sector"
+    >
+      {/* Interactive Particle Background */}
+      <ParticleBackground />
+
+      {/* Hero Section with Glitch Effect */}
+      <header className={styles.hero}>
+        <div className={styles.gridOverlay}></div>
+        <div className={styles.heroContent}>
+          <GlitchText text="GovTech Hackathon" element="h1" />
+          <div className={styles.heroTagline}>
+            <span className={styles.bracket}>{`{`}</span>
+            <span className={styles.taglineText}>Boost the Public Sector</span>
+            <span className={styles.bracket}>{`}`}</span>
+          </div>
+          <div className={styles.heroSubtitle}>
+            <h2>The Hackathon on October 11th & 12th, 2025 in Saarland</h2>
+          </div>
+          <CountdownTimer targetDate="2025-10-11T00:00:00" />
+
+          {/* Explanation moved under countdown timer as requested */}
+          <div className={styles.heroExplanation}>
+            <p className={styles.explanationText}>
+              In the heart of Europe, where Germany, France, and Luxembourg 
+              meet, we're shaping the future of the public sector. Saarland 
+              as an innovative technology hub and bridge between cultures 
+              provides the perfect setting for our GovTech Hackathon – an 
+              intense creative and programming marathon where visionary minds 
+              from various disciplines develop groundbreaking solutions for 
+              tomorrow's digital administration in just 48 hours.
+            </p>
+          </div>
+
+          <div className={styles.heroButtons}>
+            <a href="anmelden" className={styles.primaryBtn}>
+              <span className={styles.btnGlow}></span>
+              <span>Register now</span>
+            </a>
+            <a href="docs/faq" className={styles.secondaryBtn}>
+              <span>More Info</span>
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <main className={styles.mainContent}>
+        {/* Timeline Section */}
+        <section className={styles.terminalSection}>
+          <div className={styles.terminalHeader}>
+            <div className={styles.terminalControls}>
+              <span className={styles.terminalCircle}></span>
+              <span className={styles.terminalCircle}></span>
+              <span className={styles.terminalCircle}></span>
+            </div>
+            <div className={styles.terminalTitle}>Event Details</div>
+          </div>
+          <div className={styles.terminal}>
+            <div className={styles.terminalLine}>
+              <span className={styles.comment}>
+                # Mark your calendar: The GovTech event of the year!
+              </span>
+            </div>
+            <div className={styles.terminalLine}>
+              <span className={styles.output}>
+                Starting October 11th, 2025: In just 48 hours, we'll develop 
+                new solutions for pressing challenges in the public sector. 
+                Join us when creativity meets technology – and help shape 
+                tomorrow's future.
+              </span>
+            </div>
+          </div>
+        </section>
+
+        {/* "WHERE" Section with Map/Coordinates */}
+        <section className={styles.whereSection}>
+          <div className={styles.whereContent}>
+            <h2 className={styles.sectionTitle}>Venue</h2>
+            <div className={styles.whereData}>
+              <div className={styles.whereCoordinates}>
+                <div className={styles.coordinateColumn}>
+                  <div className={styles.coordLabel}>LOCATION</div>
+                  <div className={styles.coordValue}>East Side Fab e.V.</div>
+                </div>
+                <div className={styles.coordinateColumn}>
+                  <div className={styles.coordLabel}>ADDRESS</div>
+                  <div className={styles.coordValue}>
+                    Eschberger Weg 40
+                    <br />
+                    66121 Saarbrücken
+                  </div>
+                </div>
+                <div className={styles.coordinateColumn}>
+                  <div className={styles.coordLabel}>COORDINATES</div>
+                  <div className={styles.coordValue}>49.2354° N, 7.0085° E</div>
+                </div>
+                <div className={styles.coordinateColumn}>
+                  <a
+                    href="https://www.google.com/maps/dir/?api=1&destination=East+Side+Fab+Eschberger+Weg+40+66121+Saarbrücken"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.mapsLink}
+                  >
+                    <span className={styles.mapsIcon}>📍</span> Navigate with Google Maps
+                  </a>
+                </div>
+              </div>
+
+              <div className={styles.whereMap}>
+                <div className={styles.mapContainer}>
+                  <div className={styles.mapGrid}></div>
+                  <iframe
+                    width="100%"
+                    height="100%"
+                    src="https://www.openstreetmap.org/export/embed.html?bbox=7.02902913093567%2C49.227831153236366%2C7.033041715621949%2C49.22910631917016&amp;layer=mapnik"
+                  ></iframe>
+                  <br />
+                  <small>
+                    <a href="https://www.openstreetmap.org/node/7473709615">
+                      View larger map
+                    </a>
+                  </small>
+                  <div className={styles.mapPulse}></div>
+                  <div className={styles.mapOverlay}></div>
+
+                  {/* Venue Name Label */}
+                  <div className={styles.mapVenueLabel}>
+                    <span className={styles.mapVenueName}>
+                      East Side Fab e.V.
+                    </span>
+                  </div>
+
+                  <a
+                    href="https://www.openstreetmap.org/node/7473709615"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.mapLinkOverlay}
+                  >
+                    <span className={styles.mapLinkText}>Enlarge map</span>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Challenges Section - NOW WITH CAROUSEL */}
+        <section className={styles.challengesSection}>
+          <h2 className={styles.sectionTitle}>Challenges</h2>
+          {/* Old static cards removed, TopicCarousel added below */}
+          <TopicCarousel />
+        </section>
+
+        {/* CTA Section */}
+        <section className={styles.ctaSection}>
+          <div className={styles.ctaGlow}></div>
+          <h2 className={styles.ctaTitle}>Be Part of the Change</h2>
+          <p className={styles.ctaText}>
+            Secure your place now and help shape the future of the public sector
+          </p>
+          <div className={styles.ctaButtonContainer}>
+            <a href="anmelden" className={styles.ctaButton}>
+              Register now
+            </a>
+          </div>
+        </section>
+
+        {/* Partners Section */}
+        <section className={styles.partnersSection}>
+          <h2 className={styles.sectionTitle}>Partners</h2>
+          <div className={styles.partnersLogos}>
+            <div className={styles.partnerItem}>
+              <img
+                src="img/logos/partner1.png"
+                alt="Partner 1"
+                className={styles.partnerLogo}
+              />
+            </div>
+            <div className={styles.partnerItem}>
+              <img
+                src="img/logos/partner2.png"
+                alt="Partner 2"
+                className={styles.partnerLogo}
+              />
+            </div>
+            <div className={styles.partnerItem}>
+              <img
+                src="img/logos/partner3.png"
+                alt="Partner 3"
+                className={styles.partnerLogo}
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* Sponsors Section */}
+        <section className={styles.sponsorsSection}>
+          <h2 className={styles.sectionTitle}>Sponsored by</h2>
+          <div className={styles.sponsorsLogos}>
+            <div className={styles.sponsorItem}>
+              <img
+                src="img/logos/sponsor1.png"
+                alt="Sponsor 1"
+                className={styles.sponsorLogo}
+              />
+            </div>
+            <div className={styles.sponsorItem}>
+              <img
+                src="img/logos/sponsor2.png"
+                alt="Sponsor 2"
+                className={styles.sponsorLogo}
+              />
+            </div>
+            <div className={styles.sponsorItem}>
+              <img
+                src="img/logos/sponsor3.png"
+                alt="Sponsor 3"
+                className={styles.sponsorLogo}
+              />
+            </div>
+          </div>
+        </section>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
Add complete internationalization support to accommodate English-speaking participants interested in the hackathon.

## Changes
- Configure Docusaurus i18n with German as default locale and English as secondary
- Add language dropdown to navbar for easy switching
- Create complete English translations for all main pages
- Set up translation files for navbar, footer, and theme components
- Enable proper URL routing with /en/ prefix for English pages

Resolves #16

Generated with [Claude Code](https://claude.ai/code)