### PR TITLE
fix: update GovTech newsletter checkbox text to correct legal language

### DIFF
--- a/src/pages/anmelden.en.tsx
+++ b/src/pages/anmelden.en.tsx
@@ -195,13 +195,11 @@ const RegistrationForm = () => {
                     className={styles.checkbox}
                   />
                   <span className={styles.checkboxText}>
-                    Yes, I subscribe to the East Side Fab newsletter to receive 
-                    information about other exciting events and updates.
-                    Information about{" "}
+                    I hereby agree that East Side Fab e.V. as part of the European Digital Innovation Hub (EDIH Saarland) as a cooperation partner of the event "GovTech Hackathon Saarland" may use my e-mail address to send advertising for similar goods/services. You can revoke your consent at any time vis-à-vis East Side Fab e.V., without affecting the lawfulness of processing based on consent before its withdrawal. I have taken note of this information and the{" "}
                     <Link to="/datenschutz" className={styles.privacyLink}>
-                      data protection
-                    </Link>{" "}
-                    and revocation have been read.
+                      privacy policy
+                    </Link>
+                    .
                   </span>
                 </label>
               </div>

--- a/src/pages/anmelden.tsx
+++ b/src/pages/anmelden.tsx
@@ -195,13 +195,11 @@ const RegistrationForm = () => {
                     className={styles.checkbox}
                   />
                   <span className={styles.checkboxText}>
-                    Ja, ich abonniere den Newsletter des East Side Fabs um über
-                    weitere spannende Events und Informationen zu erhalten.
-                    Hinweise zum{" "}
+                    Hiermit stimme ich zu, dass der East Side Fab e.V. im Rahmen des European Digital Innovation Hubs (EDIH Saarland) als Kooperationspartner der Veranstaltung "GovTech Hackathon Saarland" meine E-Mail-Adresse zum Versand von Werbung für ähnliche Waren / Dienstleistungen verwenden darf. Sie können Ihre Einwilligung jederzeit gegenüber dem East Side Fab e.V. widerrufen, ohne dass die Rechtmäßigkeit der aufgrund der Einwilligung bis zum Widerruf erfolgten Verarbeitung berührt wird. Ich habe diesen Hinweis und die{" "}
                     <Link to="/datenschutz" className={styles.privacyLink}>
-                      Datenschutz
+                      Datenschutzerklärung
                     </Link>{" "}
-                    und Widerruf habe ich gelesen.
+                    zur Kenntnis genommen.
                   </span>
                 </label>
               </div>


### PR DESCRIPTION
Updates the newsletter checkbox text in both German and English registration forms with the correct GDPR-compliant legal language.

## Changes
- Updated German checkbox text to exact legal wording as requested
- Added proper English translation for newsletter consent
- Both versions now include full GDPR-compliant consent text
- Reference East Side Fab e.V. and EDIH Saarland partnership

Closes #18

Generated with [Claude Code](https://claude.ai/code)